### PR TITLE
Mount boot partition before loading kernel modules

### DIFF
--- a/layers/meta-resin-revpi-core-3/recipes-support/resin-mounts/files/resin-boot.conf
+++ b/layers/meta-resin-revpi-core-3/recipes-support/resin-mounts/files/resin-boot.conf
@@ -1,0 +1,2 @@
+[Unit]
+Before=systemd-modules-load.service

--- a/layers/meta-resin-revpi-core-3/recipes-support/resin-mounts/resin-mounts.bbappend
+++ b/layers/meta-resin-revpi-core-3/recipes-support/resin-mounts/resin-mounts.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+	file://resin-boot.conf \
+"
+
+do_install_append() {
+	install -d ${D}${sysconfdir}/systemd/system/resin-boot.service.d
+	install -m 0644 resin-boot.conf ${D}${sysconfdir}/systemd/system/resin-boot.service.d/
+}


### PR DESCRIPTION
Because the kernel modules are loaded before mounting /mnt/boot partition, the piControl
module is unable to find the configuration file which resides in /mnt/boot.
This patch forces the mounting of the boot partition before starting the kernel module loading
service.

Changelog-entry: resin-mounts: Mount boot partition before loading kernel modules
Signed-off-by: Sebastian Panceac <sebastian@resin.io>