### PR TITLE
layers/meta-resin: Update meta-resin to v2.19.0

### DIFF
--- a/layers/meta-resin-revpi-core-3/conf/layer.conf
+++ b/layers/meta-resin-revpi-core-3/conf/layer.conf
@@ -115,7 +115,7 @@ KERNEL_DEVICETREE_append = " \
     overlays/wittypi.dtbo \
 "
 
-KERNEL_DEVICETREE_append = " overlays/balena-fin.dtbo"
+KERNEL_DEVICETREE_remove = "overlays/rpi-poe.dtbo"
 
 # We use udev rules to create serial device aliases
 SERIAL_CONSOLE = "115200 serial0"


### PR DESCRIPTION
Update meta-resin from 2.15.1 to 2.19.0

Changelog-entry: Update the meta-resin submodule from v2.15.1 to v2.19.0
Signed-off-by: Florin Sarbu <florin@resin.io>